### PR TITLE
Set raven as global `window.Raven` object

### DIFF
--- a/view/frontend/templates/sentry.phtml
+++ b/view/frontend/templates/sentry.phtml
@@ -51,6 +51,9 @@ if ($sentryDSN):
                 <?= $customConfiguration; ?>
             );
             raven.config('<?=$sentryDSN;?>', ravenOptions).install();
+            if (!window.Raven) {
+                window.Raven = raven;
+            }
 
             require(['jquery/jquery-storageapi'], function() {
                 var scramble = function(data) {


### PR DESCRIPTION
It's often quite useful to send a warning to Sentry ( https://docs.sentry.io/clients/javascript/usage/#raven-js-additional-context ) without having to throw an actual js error that would break the code flow.

I know one could already do it using

```
require(['raven'], raven => raven.captureMessage(...))
```

but this will trigger an error if `raven` is not existant in requirejs scope (which might happen if this module is disabled on some environments).

Thanks to this, I'll be able to do in theme-creativeshop stuff like this:

```
if (window.Raven) {
  Raven.captureMessage(...);
}
```

which I'd like to do for JS errors that I already know of, but haven't found a total fix yet ( https://github.com/magesuite/theme-creativeshop/pull/48 for example), and would like to track them on Sentry.