### PR TITLE
fix: Remove needless console.log from sentry.phtml

### DIFF
--- a/view/frontend/templates/sentry.phtml
+++ b/view/frontend/templates/sentry.phtml
@@ -44,7 +44,6 @@ if ($sentryDSN):
                     ],
                     release: '<?= $this->getMagentoVersion(); ?>',
                     shouldSendCallback: function() {
-                        console.log(isLeavingPage);
                         return !isLeavingPage;
                     }
                 },


### PR DESCRIPTION
Currently we see quite a meaningless `false` log entry in the web console when page is loaded:

![image](https://user-images.githubusercontent.com/1862580/133407170-92414d93-8cce-400f-8dd2-3ed4f6ea4162.png)

I guess that `console.log` has been left there accidentally? Let's remove it?