### PR TITLE
fix: Prevent errors from different versions to be grouped separately in Sentry

### DIFF
--- a/view/frontend/templates/sentry.phtml
+++ b/view/frontend/templates/sentry.phtml
@@ -46,6 +46,12 @@ if ($sentryDSN):
                     shouldSendCallback: function() {
                         console.log(isLeavingPage);
                         return !isLeavingPage;
+                    },
+                    dataCallback: function(event) {
+                        if (event.transaction) {
+                            event.transaction = event.transaction.replace(/\/static\/version[0-9]+\//, "/static/");
+                        }
+                        return event;
                     }
                 },
                 <?= $customConfiguration; ?>


### PR DESCRIPTION
Errors in Sentry are grouped e.g. by their message and by the URL of JS file from which the error comes from.

In Magento the URLs of the JS files are different per each deploy - as on each deploy, a new `versionXXXX` directory is created.

This makes errors appear as separate ones in Sentry, if they happened in separate releases, even if they look exactly the same.

So what we can do instead, is transform the event payload before it's being sent to Sentry, strip out the `/versionXXXX/` path from the js file url, and then send it.

This PR does it.