### PR TITLE
Do not escapeHtml the $customConfiguration

### DIFF
--- a/view/frontend/templates/sentry.phtml
+++ b/view/frontend/templates/sentry.phtml
@@ -56,7 +56,7 @@ $customConfiguration = $viewModel->getCustomConfiguration() ?? '{}';
 
     const options = {
         ...defaultConfig,
-        ...<?= $escaper->escapeHtml($customConfiguration); ?>
+        ...<?= $customConfiguration ?>
     }
 
     Sentry.init(options);


### PR DESCRIPTION
The $customConfiguration should not be processed by escapeHtml, as it makes unable to write anything in Custom configuration

Example:
{ environment: "predev" }

Is being changed into:
{ environment: \&quot;predev\&quot; }